### PR TITLE
更新部分下载链接  

### DIFF
--- a/assets/scripts/configs/download-config.js
+++ b/assets/scripts/configs/download-config.js
@@ -1,10 +1,15 @@
 // 下载链接配置  全是小写
+
+// zjh 
+
+
+
 const downloadLinks = {
     // clash verge
     'clash verge': {
-        windows: 'https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.0/Clash.Verge_2.2.0_x64-setup.exe',
-        mac: 'https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.0/Clash.Verge_2.2.0_x64.dmg',
-        linux: 'https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.0/Clash.Verge-2.2.0-1.x86_64.rpm',
+        windows: 'https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64-setup.exe',
+        mac: 'https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge_2.2.2_x64.dmg',
+        linux: 'https://github.com/clash-verge-rev/clash-verge-rev/releases/download/v2.2.2/Clash.Verge-2.2.2-1.x86_64.rpm',
         github: 'https://github.com/clash-verge-rev/clash-verge-rev'
     },
     // mihomo party
@@ -16,17 +21,19 @@ const downloadLinks = {
     },
     // clashmeta
     'clashmeta': {
-        android: 'https://github.com/MetaCubeX/ClashMetaForAndroid/releases/download/v2.11.5/cmfa-2.11.4-meta-universal-release.apk',
+        android: 'https://github.com/MetaCubeX/ClashMetaForAndroid/releases/download/v2.11.7/cmfa-2.11.7-meta-x86_64-release.apk',
         github: 'https://github.com/MetaCubeX/ClashMetaForAndroid'
     },
     // surfboard
     'surfboard': {
-        android: 'https://github.com/getsurfboard/surfboard/releases/download/2.24.9/mobile-universal-release.apk',
+        android: 'https://github.com/getsurfboard/surfboard/releases/download/mobile-2.24.10/mobile-universal-release.apk',
         github: 'https://github.com/getsurfboard/surfboard'
     },
     // v2rayn
     'v2rayn': {
-        windows: 'https://github.com/2dust/v2rayN/releases/download/7.7.0/v2rayN-With-Core.zip',
+        windows: 'https://github.com/2dust/v2rayN/releases/download/7.10.5/v2rayN-windows-64.zip',
+        mac:'https://github.com/2dust/v2rayN/releases/download/7.10.5/v2rayN-macos-64.dmg',
+        linux: 'https://github.com/2dust/v2rayN/releases/download/7.10.5/v2rayN-linux-64.zip',
         github: 'https://github.com/2dust/v2rayN'
     },
     // v2rayn

--- a/assets/scripts/configs/download-config.js
+++ b/assets/scripts/configs/download-config.js
@@ -38,7 +38,7 @@ const downloadLinks = {
     },
     // v2rayn
     'v2rayng': {
-        android: 'https://github.com/2dust/v2rayNG/releases/download/1.9.31/v2rayNG_1.9.31_universal.apk',
+        android: 'https://github.com/2dust/v2rayNG/releases/download/1.9.39/v2rayNG_1.9.39_universal.apk',
         github: 'https://github.com/2dust/v2rayNG'
     },
     // singbox


### PR DESCRIPTION
clash verge
clashmeta
surfboard
v2rayn（增加了mac和linux的下载地址）
v2rayng